### PR TITLE
Move header tokens from foundations to component

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@inubekit/foundations": "^5.11.2",
-    "@inubekit/fullscreennav": "^2.4.0",
+    "@inubekit/fullscreennav": "^2.36.0",
     "@inubekit/hooks": "^1.2.0",
     "@inubekit/icon": "^2.16.0",
     "@inubekit/stack": "^3.8.0",

--- a/src/Header/Tokens/tokens.ts
+++ b/src/Header/Tokens/tokens.ts
@@ -1,0 +1,12 @@
+import { inube } from "@inubekit/foundations";
+
+const tokens = {
+  background: {
+    color: inube.palette.neutral.N0,
+  },
+  content: {
+    appearance: "gray",
+  },
+};
+
+export { tokens };

--- a/src/Header/index.tsx
+++ b/src/Header/index.tsx
@@ -1,6 +1,5 @@
 import { useContext } from "react";
 import { ThemeContext } from "styled-components";
-import { inube } from "@inubekit/foundations";
 import { User } from "@inubekit/user";
 import { useMediaQueries } from "@inubekit/hooks";
 import { Stack } from "@inubekit/stack";
@@ -8,6 +7,7 @@ import { ITextAppearance, Text } from "@inubekit/text";
 import { FullscreenNav, IFNavigation } from "@inubekit/fullscreennav";
 import { IHeaderLink } from "./props";
 import { StyledHeader, StyledLink } from "./styles";
+import { tokens } from "./Tokens/tokens";
 
 interface IHeader {
   portalId: string;
@@ -31,10 +31,10 @@ const Header = (props: IHeader) => {
     showLinks = false,
     showUser = true,
   } = props;
-  const theme: typeof inube = useContext(ThemeContext);
+  const theme = useContext(ThemeContext) as { header: typeof tokens };
   const linkAppearance =
     (theme?.header?.content?.appearance as ITextAppearance) ||
-    inube.header.content.appearance;
+    tokens.content.appearance;
   const [mobile, tablet] = Object.values(
     useMediaQueries(["(max-width: 420px)", "(max-width: 944px) "]),
   );


### PR DESCRIPTION
This PR relocates the header tokens from the foundations folder to the component folder, updating all necessary imports to reflect the new structure and ensuring that components reference the correct token paths. This change improves the organization, maintainability, and clarity of the codebase.