### PR TITLE
Extend `<Header />` to integrate `<User />` with custom menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@inubekit/icon": "^2.17.0",
     "@inubekit/stack": "^3.8.0",
     "@inubekit/text": "^2.17.0",
-    "@inubekit/user": "^2.9.1"
+    "@inubekit/user": "^3.0.0"
   },
   "peerDependencies": {
     "react": "^18.2.0",

--- a/src/Header/index.tsx
+++ b/src/Header/index.tsx
@@ -1,6 +1,6 @@
 import { useContext } from "react";
 import { ThemeContext } from "styled-components";
-import { User } from "@inubekit/user";
+import { IMenuSection, User } from "@inubekit/user";
 import { useMediaQueries } from "@inubekit/hooks";
 import { Stack } from "@inubekit/stack";
 import { ITextAppearance, Text } from "@inubekit/text";
@@ -18,6 +18,7 @@ interface IHeader {
   links?: IHeaderLink[];
   showLinks?: boolean;
   showUser?: boolean;
+  userMenu?: IMenuSection[];
 }
 
 const Header = (props: IHeader) => {
@@ -30,6 +31,7 @@ const Header = (props: IHeader) => {
     links,
     showLinks = false,
     showUser = true,
+    userMenu = [],
   } = props;
   const theme = useContext(ThemeContext) as { header: typeof tokens };
   const linkAppearance =
@@ -78,6 +80,7 @@ const Header = (props: IHeader) => {
               username={userName}
               client={client!}
               size={mobile ? "small" : "large"}
+              menu={userMenu}
             />
           )}
         </Stack>

--- a/src/Header/stories/Header.stories.tsx
+++ b/src/Header/stories/Header.stories.tsx
@@ -9,6 +9,9 @@ import {
   MdAccountBalance,
   MdAccountBalanceWallet,
   MdAndroid,
+  MdSettings,
+  MdPrivacyTip,
+  MdLogout,
 } from "react-icons/md";
 
 import { props, parameters } from "../props";
@@ -105,6 +108,40 @@ Default.args = {
       label: "Actualizar datos",
       path: "/update-data-assisted",
       icon: <MdAndroid />,
+    },
+  ],
+  userMenu: [
+    {
+      id: "section1",
+      title: "Profile",
+      links: [
+        {
+          id: "link1",
+          title: "Account Settings",
+          path: "/account",
+          iconBefore: <MdSettings />,
+        },
+        {
+          id: "link2",
+          title: "Privacy Settings",
+          path: "/privacy",
+          iconBefore: <MdPrivacyTip />,
+        },
+      ],
+      divider: true,
+    },
+    {
+      id: "section2",
+      title: "Actions",
+      actions: [
+        {
+          id: "action1",
+          title: "Logout",
+          action: () => console.log("Logout"),
+          iconBefore: <MdLogout />,
+        },
+      ],
+      divider: true,
     },
   ],
   showLinks: false,

--- a/src/Header/styles.js
+++ b/src/Header/styles.js
@@ -13,7 +13,6 @@ const StyledHeader = styled.header`
     0px 1px 2px 0px
       ${({ theme }) =>
         theme?.palette?.neutral?.N20 || inube.palette.neutral.N20};
-
   & > div > div > div {
     position: unset;
     display: flex;
@@ -35,6 +34,12 @@ const StyledHeader = styled.header`
     border-left: 1px solid
       ${({ theme }) =>
         theme?.palette?.neutral?.N40 || inube.palette.neutral.N40};
+  }
+
+  & > div > div > div > div:nth-child(2) {
+    position: absolute;
+    top: 4.6rem;
+    right: 1rem;
   }
 `;
 


### PR DESCRIPTION
This PR extends the `<Header />` component by integrating the new `<User />` component with support for a customizable menu. The update allows the userMenu prop to be passed to `<User />`, providing flexibility for displaying custom menu options within the header. Additionally, the layout ensures proper spacing and alignment across different screen sizes, maintaining consistent behavior whether the menu is present or not. The changes have been tested for responsiveness and functionality, ensuring smooth integration and improved user interaction within the header.